### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/857/940/61/85794061.geojson
+++ b/data/857/940/61/85794061.geojson
@@ -121,6 +121,10 @@
         "qs_pg:id":1082637
     },
     "wof:country":"BQ",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"685a957ffa604a1948d0b633dc02f328",
     "wof:hierarchy":[
         {
@@ -137,7 +141,7 @@
     "wof:lang":[
         "dut"
     ],
-    "wof:lastmodified":1566618150,
+    "wof:lastmodified":1582331169,
     "wof:name":"Prospect",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/429/299/890429299.geojson
+++ b/data/890/429/299/890429299.geojson
@@ -177,6 +177,9 @@
     },
     "wof:country":"BQ",
     "wof:created":1469051806,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7c92353f48d4c677837d86d14900716",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":890429299,
-    "wof:lastmodified":1566618155,
+    "wof:lastmodified":1582331169,
     "wof:name":"The Bottom",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/434/825/890434825.geojson
+++ b/data/890/434/825/890434825.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"BQ",
     "wof:created":1469052041,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1c45bd237eea1c5b848b49a169d5f59",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":890434825,
-    "wof:lastmodified":1566618155,
+    "wof:lastmodified":1582331169,
     "wof:name":"Kralendijk",
     "wof:parent_id":85675535,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.