### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/890/429/295/890429295.geojson
+++ b/data/890/429/295/890429295.geojson
@@ -22,6 +22,12 @@
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0423\u0456\u043d\u0434\u0432\u0430\u0440\u0434\u0441\u0430\u0439\u0434"
     ],
+    "name:bel_x_variant":[
+        "\u0423\u0456\u043d\u0434\u0432\u0430\u0440\u0434\u0441\u0430\u0439\u0434"
+    ],
+    "name:ceb_x_preferred":[
+        "Windward Side"
+    ],
     "name:deu_x_preferred":[
         "Windwardside"
     ],
@@ -39,6 +45,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0548\u0582\u056b\u0576\u0564\u0578\u0582\u0561\u0580\u0564\u057d\u0561\u056b\u0564"
+    ],
+    "name:ita_x_preferred":[
+        "Windwardside"
     ],
     "name:nld_x_preferred":[
         "Windwardside"
@@ -58,8 +67,14 @@
     "name:srp_x_preferred":[
         "\u0412\u0438\u043d\u0434\u0432\u0430\u0440\u0434\u0441\u0430\u0458\u0434"
     ],
+    "name:swe_x_preferred":[
+        "Windwardside"
+    ],
     "name:ukr_x_preferred":[
         "\u0412\u0456\u043d\u0434\u0432\u0430\u0440\u0434\u0441\u0430\u0439\u0434"
+    ],
+    "name:zho_x_preferred":[
+        "\u6e29\u6c83\u585e\u5fb7"
     ],
     "qs:name":"Windward Side",
     "qs:photos_9r":0,
@@ -92,7 +107,7 @@
         }
     ],
     "wof:id":890429295,
-    "wof:lastmodified":1566618154,
+    "wof:lastmodified":1690860394,
     "wof:name":"Windward Side",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/429/299/890429299.geojson
+++ b/data/890/429/299/890429299.geojson
@@ -25,11 +25,20 @@
     "name:ara_x_preferred":[
         "\u0630\u064a \u0628\u0648\u062a\u0648\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0630\u0649 \u0628\u0648\u062a\u0648\u0645"
+    ],
+    "name:ast_x_preferred":[
+        "The Bottom"
+    ],
     "name:aze_x_preferred":[
         "Bottom"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0411\u043e\u0442\u0430\u043c"
+    ],
+    "name:bel_x_variant":[
+        "\u0411\u043e\u0442\u0430\u043c"
     ],
     "name:bos_x_preferred":[
         "The Bottom"
@@ -61,10 +70,16 @@
     "name:fao_x_preferred":[
         "The Bottom"
     ],
+    "name:fas_x_preferred":[
+        "\u062f \u0628\u0627\u062a\u0645"
+    ],
     "name:fra_x_preferred":[
         "The Bottom"
     ],
     "name:fry_x_preferred":[
+        "The Bottom"
+    ],
+    "name:glg_x_preferred":[
         "The Bottom"
     ],
     "name:heb_x_preferred":[
@@ -88,11 +103,17 @@
     "name:kor_x_preferred":[
         "\ubcf4\ud140"
     ],
+    "name:lav_x_preferred":[
+        "Botoma"
+    ],
     "name:lit_x_preferred":[
         "Botomas"
     ],
     "name:lmo_x_preferred":[
         "The Bottom"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0411\u043e\u0442\u043e\u043c"
     ],
     "name:nan_x_preferred":[
         "The Bottom"
@@ -102,6 +123,9 @@
     ],
     "name:nob_x_preferred":[
         "The Bottom"
+    ],
+    "name:oss_x_preferred":[
+        "\u0411\u043e\u0442\u0442\u043e\u043c"
     ],
     "name:pms_x_preferred":[
         "The Bottom"
@@ -116,6 +140,9 @@
         "\u0411\u043e\u0442\u0442\u043e\u043c"
     ],
     "name:sco_x_preferred":[
+        "The Bottom"
+    ],
+    "name:slk_x_preferred":[
         "The Bottom"
     ],
     "name:spa_x_preferred":[
@@ -145,8 +172,14 @@
     "name:war_x_preferred":[
         "The Bottom"
     ],
+    "name:wuu_x_preferred":[
+        "\u535a\u6258\u59c6"
+    ],
     "name:zho_x_preferred":[
         "\u535a\u5766"
+    ],
+    "name:zho_x_variant":[
+        "\u535a\u6258\u59c6"
     ],
     "qs:name":"The Bottom",
     "qs:photos_9r":0,
@@ -192,7 +225,7 @@
         }
     ],
     "wof:id":890429299,
-    "wof:lastmodified":1582331169,
+    "wof:lastmodified":1690860395,
     "wof:name":"The Bottom",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/890/434/825/890434825.geojson
+++ b/data/890/434/825/890434825.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0631\u0627\u0644\u064a\u0646\u062f\u0627\u064a\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0631\u0627\u0644\u064a\u0646\u062f\u0627\u064a\u0643"
+    ],
     "name:ast_x_preferred":[
         "Kralendijk"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0440\u0430\u043b\u0435\u043d\u0434\u044d\u0439\u043a"
+    ],
+    "name:bel_x_variant":[
+        "\u041a\u0440\u0430\u043b\u0435\u043d\u0434\u044d\u0439\u043a"
     ],
     "name:bos_x_preferred":[
         "Kralendijk"
@@ -73,6 +79,9 @@
     "name:fry_x_preferred":[
         "Kralendijk"
     ],
+    "name:glg_x_preferred":[
+        "Kralendijk"
+    ],
     "name:hye_x_preferred":[
         "\u053f\u0580\u0561\u056c\u0565\u0576\u0564\u056b\u0575\u056f"
     ],
@@ -90,6 +99,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud06c\ub784\ub80c\ub370\uc774\ud06c"
+    ],
+    "name:lav_x_preferred":[
+        "Kr\u0101lendeika"
     ],
     "name:lit_x_preferred":[
         "Kralendeikas"
@@ -130,7 +142,13 @@
     "name:sco_x_preferred":[
         "Kralendijk"
     ],
+    "name:slk_x_preferred":[
+        "Kralendijk"
+    ],
     "name:spa_x_preferred":[
+        "Kralendijk"
+    ],
+    "name:srd_x_preferred":[
         "Kralendijk"
     ],
     "name:srp_x_preferred":[
@@ -154,11 +172,17 @@
     "name:urd_x_preferred":[
         "\u06a9\u0631\u0627\u0644\u0646\u062f\u06cc\u06a9"
     ],
+    "name:uzb_x_preferred":[
+        "Kralendeyk"
+    ],
     "name:vie_x_preferred":[
         "Kralendijk"
     ],
     "name:war_x_preferred":[
         "Kralendijk"
+    ],
+    "name:wuu_x_preferred":[
+        "\u514b\u62c9\u4f26\u4ee3\u514b"
     ],
     "name:zho_x_preferred":[
         "\u514b\u62c9\u4f26\u4ee3\u514b"
@@ -208,7 +232,7 @@
         }
     ],
     "wof:id":890434825,
-    "wof:lastmodified":1582331169,
+    "wof:lastmodified":1690860395,
     "wof:name":"Kralendijk",
     "wof:parent_id":85675535,
     "wof:placetype":"locality",

--- a/data/890/440/111/890440111.geojson
+++ b/data/890/440/111/890440111.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0631\u0627\u0646\u064a\u0627\u0633\u062a\u0627\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0631\u0627\u0646\u064a\u0627\u0633\u062a\u0627\u062f"
+    ],
     "name:ast_x_preferred":[
         "Oranxestad"
     ],
@@ -35,7 +38,8 @@
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0440\u0430\u043d\u044c\u0435\u0441\u0442\u0430\u0434"
     ],
     "name:bel_x_variant":[
-        "\u0413\u043e\u0440\u0430\u0434 \u0410\u0440\u0430\u043d'\u0435\u0441\u0442\u0430\u0434"
+        "\u0413\u043e\u0440\u0430\u0434 \u0410\u0440\u0430\u043d'\u0435\u0441\u0442\u0430\u0434",
+        "\u0410\u0440\u0430\u043d\u044c\u0435\u0441\u0442\u0430\u0434"
     ],
     "name:ben_x_preferred":[
         "\u0993\u09b0\u09be\u099e\u09cd\u099c\u09c7\u09b8\u09cd\u09a4\u09be\u09a6"
@@ -64,6 +68,9 @@
     "name:epo_x_preferred":[
         "Oranjestado"
     ],
+    "name:eus_x_preferred":[
+        "Oranjestad"
+    ],
     "name:fas_x_preferred":[
         "\u0627\u0648\u0631\u0646\u06cc\u0633\u062a\u0627\u062a"
     ],
@@ -75,6 +82,9 @@
     ],
     "name:fry_x_preferred":[
         "Oranjest\u00ead"
+    ],
+    "name:glg_x_preferred":[
+        "Oranjestad"
     ],
     "name:heb_x_preferred":[
         "\u05d0\u05d5\u05e8\u05e0\u05d9\u05d9\u05e1\u05d8\u05d0\u05d3"
@@ -100,11 +110,20 @@
     "name:kor_x_preferred":[
         "\uc624\ub77c\ub15c\uc2a4\ud0c0\ud2b8"
     ],
+    "name:lat_x_preferred":[
+        "Auriacopolis"
+    ],
+    "name:lav_x_preferred":[
+        "Oranjestade"
+    ],
     "name:lit_x_preferred":[
         "Oranjestadas"
     ],
     "name:lmo_x_preferred":[
         "Oranjestad"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041e\u0440\u0430\u045a\u0435\u0441\u0442\u0430\u0434"
     ],
     "name:nan_x_preferred":[
         "Oranjestad"
@@ -114,6 +133,9 @@
     ],
     "name:nno_x_preferred":[
         "Oranjestad p\u00e5 Sint Eustatius"
+    ],
+    "name:nno_x_variant":[
+        "Oranjestad"
     ],
     "name:nob_x_preferred":[
         "Oranjestad"
@@ -165,6 +187,12 @@
     ],
     "name:vie_x_preferred":[
         "Oranjestad"
+    ],
+    "name:war_x_preferred":[
+        "Oranjestad"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5965\u62c9\u6d85\u65af\u5854\u5fb7"
     ],
     "name:zho_x_preferred":[
         "\u5965\u62c9\u6d85\u65af\u5854\u5fb7"
@@ -298,7 +326,7 @@
         }
     ],
     "wof:id":890440111,
-    "wof:lastmodified":1636497450,
+    "wof:lastmodified":1690860394,
     "wof:name":"Oranjestad",
     "wof:parent_id":85675531,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.